### PR TITLE
Code Review: Document the generated content in the developer website (#10984)

### DIFF
--- a/SVGO Export.sketchplugin/Contents/Sketch/svgo-export.js
+++ b/SVGO Export.sketchplugin/Contents/Sketch/svgo-export.js
@@ -1,8 +1,12 @@
 // SVGO Export, by Ale Muñoz — Source code available at [GitHub](https://github.com/BohemianCoding/plugins.examples.svgo-export)
 //
-// This Plugin compresses SVG assets using [SVGO](https://github.com/svg/svgo) right after they're exported from Sketch.
+// This Plugin compresses SVG assets using SVGO right after they're exported from Sketch.
+
 //
-// It uses the new Action API in Sketch 3.8, and requires svgo to be installed in `/usr/local/bin`
+// ### Dependencies
+//
+// This plugin requires [svgo](https://github.com/svg/svgo) to be installed in `/usr/local/bin`
+
 //
 // ### Manifest
 // This is the content of the `manifest.json` file for this Plugin. See how we're attaching the Plugin to the `ExportSlices.finish` event in `handlers.actions` by assigning a function name (`compressSVG`, defined in `svgo.js` to the action name we're interested in).


### PR DESCRIPTION
Code review for Document the generated content in the developer website (#10984):

> It makes sense to mention somewhere that the API documentation and the plugin example documentation are both auto-generated using scripts.
> 
> It might also make sense to re-organise the scripts so that they place all of the auto-generated content into a root `_generated` folder.
> 
> We can then tell everyone "don't hand-edit anything in _generated, there's no point".


Connect to BohemianCoding/Sketch#10984.